### PR TITLE
fix: standardize font sizes to 16px base

### DIFF
--- a/src/components/ArticlePage.tsx
+++ b/src/components/ArticlePage.tsx
@@ -59,7 +59,7 @@ const ArticlePage: React.FC = () => {
       <Frame variant="raised" className="main-frame">
         <div style={{ marginBottom: '20px' }}>
           <Link to="/" style={{ textDecoration: 'none' }}>
-            <Button style={{ fontSize: '1.2rem', padding: '8px 16px' }}>← Back to Blog95</Button>
+            <Button style={{ fontSize: '1rem', padding: '8px 16px' }}>← Back to Blog95</Button>
           </Link>
         </div>
 
@@ -72,7 +72,7 @@ const ArticlePage: React.FC = () => {
           />
           <div className="article-hero-content">
             <h1 style={{ 
-              fontSize: '2rem', 
+              fontSize: '2.5rem', 
               color: '#000080', 
               margin: '0 0 10px 0',
             }}>
@@ -92,7 +92,7 @@ const ArticlePage: React.FC = () => {
                     display: 'flex',
                     alignItems: 'center',
                     gap: '4px',
-                    fontSize: '1.2rem',
+                    fontSize: '1rem',
                     padding: '8px 16px'
                   }}
                 >
@@ -107,7 +107,7 @@ const ArticlePage: React.FC = () => {
         <Frame variant="sunken" style={{ padding: '20px', marginBottom: '30px' }}>
           <div style={{ 
             lineHeight: '1.6', 
-            fontSize: '1.2rem',
+            fontSize: '1rem',
             color: '#222'
           }}>
             {article.content.split('\n\n').map((paragraph, index) => (
@@ -122,7 +122,7 @@ const ArticlePage: React.FC = () => {
         <Frame variant="raised" style={{ padding: '20px' }}>
           <h2 style={{ 
             color: '#000080', 
-            fontSize: '1.5rem', 
+            fontSize: '2rem', 
             marginBottom: '20px',
             borderBottom: '2px solid #c0c0c0',
             paddingBottom: '10px'
@@ -138,7 +138,7 @@ Comments ({comments.length})
                 padding: '15px'
               }}>
                 <div style={{ 
-                  fontSize: '1.3rem', 
+                  fontSize: '1.125rem', 
                   fontWeight: 'bold', 
                   color: '#000080',
                   marginBottom: '5px',
@@ -149,7 +149,7 @@ Comments ({comments.length})
                   <User3 style={{ width: '16px', height: '16px' }} /> {comment.author}
                 </div>
                 <div style={{ 
-                  fontSize: '1.2rem', 
+                  fontSize: '0.875rem', 
                   color: '#666',
                   marginBottom: '10px',
                   display: 'flex',
@@ -158,7 +158,7 @@ Comments ({comments.length})
                 }}>
                   <Time style={{ width: '16px', height: '16px' }} /> {comment.timestamp}
                 </div>
-                <div style={{ fontSize: '1.3rem', lineHeight: '1.4', color: '#333' }}>
+                <div style={{ fontSize: '1rem', lineHeight: '1.4', color: '#333' }}>
                   {comment.content}
                 </div>
               </Frame>
@@ -168,7 +168,7 @@ Comments ({comments.length})
           {/* Add Comment Form */}
           <Fieldset legend="Leave a Comment" style={{ padding: '20px' }}>
             <h3 style={{ 
-              fontSize: '1.4rem', 
+              fontSize: '1.5rem', 
               marginBottom: '15px',
               color: '#000080'
             }}>
@@ -179,7 +179,7 @@ Leave a Comment
               <label style={{ 
                 display: 'block', 
                 marginBottom: '5px',
-                fontSize: '1.3rem',
+                fontSize: '1rem',
                 fontWeight: 'bold',
                 color: '#333'
               }}>
@@ -194,7 +194,7 @@ Leave a Comment
                   width: '100%',
                   padding: '5px',
                   border: '2px inset #c0c0c0',
-                  fontSize: '1.1rem'
+                  fontSize: '1rem'
                 }}
               />
             </div>
@@ -203,7 +203,7 @@ Leave a Comment
               <label style={{ 
                 display: 'block', 
                 marginBottom: '5px',
-                fontSize: '1.3rem',
+                fontSize: '1rem',
                 fontWeight: 'bold',
                 color: '#333'
               }}>
@@ -221,7 +221,7 @@ Leave a Comment
             <Button 
               onClick={handleCommentSubmit}
               disabled={!newComment.trim() || !commentAuthor.trim()}
-              style={{ fontSize: '1.3rem', padding: '10px 20px' }}
+              style={{ fontSize: '1rem', padding: '10px 20px' }}
             >
 Post Comment
             </Button>

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -17,13 +17,13 @@ const HomePage: React.FC = () => {
           }}>
 The Amazing Blog95
           </h1>
-          <p style={{ fontSize: '1.1rem', color: '#000', marginBottom: '20px' }}>
+          <p style={{ fontSize: '1rem', color: '#000', marginBottom: '20px' }}>
             Your Premier Source for Technology News in the Digital Age
           </p>
         </div>
 
         <Frame variant="sunken" style={{ padding: '15px', marginBottom: '20px' }}>
-          <h2 style={{ color: '#000080', fontSize: '1.3rem', marginBottom: '15px' }}>
+          <h2 style={{ color: '#000080', fontSize: '2rem', marginBottom: '15px' }}>
 Latest Articles
           </h2>
           
@@ -39,14 +39,14 @@ Latest Articles
                 <h3 style={{ 
                   margin: '0 0 8px 0', 
                   color: '#000080',
-                  fontSize: '1.4rem'
+                  fontSize: '1.5rem'
                 }}>
                   {article.title}
                 </h3>
                 
                 <p style={{ 
                   margin: '0 0 10px 0', 
-                  fontSize: '1.2rem',
+                  fontSize: '1rem',
                   color: '#333',
                   lineHeight: '1.4'
                 }}>
@@ -62,7 +62,7 @@ Latest Articles
                   </div>
                   
                   <Link to={`/article/${article.id}`} style={{ textDecoration: 'none' }}>
-                    <Button style={{ fontSize: '1.2rem', padding: '8px 16px' }}>Read More</Button>
+                    <Button style={{ fontSize: '1rem', padding: '8px 16px' }}>Read More</Button>
                   </Link>
                 </div>
               </div>
@@ -84,7 +84,7 @@ Latest Articles
           </Link>
         </div>
         
-        <div style={{ textAlign: 'center', fontSize: '0.8rem', color: '#666' }}>
+        <div style={{ textAlign: 'center', fontSize: '0.875rem', color: '#666' }}>
           <p>© 1995 The Amazing Blog95 • Powered by Windows 95 Technology</p>
         </div>
       </Frame>

--- a/src/index.css
+++ b/src/index.css
@@ -71,7 +71,7 @@ body {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  font-size: 1.2rem;
+  font-size: 1rem;
 }
 
 .metadata-items {
@@ -151,7 +151,7 @@ body {
 }
 
 .article-hero-meta-left {
-  font-size: 1.1rem;
+  font-size: 1rem;
   color: #666;
   display: flex;
   align-items: center;


### PR DESCRIPTION
Fixes #3 - Font sizes too big

## Changes
- Set body text to 16px (1rem) across all components
- Updated heading hierarchy: H1 (2.5rem), H2 (2rem), H3 (1.5rem)
- Adjusted small text to 14px (0.875rem) for better readability
- Maintained Windows 95 aesthetic while improving typography

## Files Changed
- `src/components/HomePage.tsx`
- `src/components/ArticlePage.tsx`
- `src/index.css`

Generated with [Claude Code](https://claude.ai/code)